### PR TITLE
Fixed model server test for failing predictions

### DIFF
--- a/src/test/java/ai/skymind/examples/ModelServingTest.java
+++ b/src/test/java/ai/skymind/examples/ModelServingTest.java
@@ -1,9 +1,6 @@
 package ai.skymind.examples;
 
-import ai.skymind.Deployment;
-import ai.skymind.Experiment;
-import ai.skymind.Skil;
-import ai.skymind.WorkSpace;
+import ai.skymind.*;
 import ai.skymind.models.Model;
 import ai.skymind.services.Service;
 import org.junit.Test;
@@ -34,10 +31,26 @@ public class ModelServingTest {
                 deployment, true, 1, null, null, false
         );
 
-        INDArray data = Nd4j.rand(1, 784);
-        // Single Predict
-        System.out.println(service.predictSingle(data, "default"));
-        // Multi Predict
-        System.out.println(Arrays.toString(service.predict(new INDArray[] {data}, "default")));
+        int retryCount = 2;
+        int retries = 0;
+
+        do {
+            retries++;
+
+            try {
+                INDArray data = Nd4j.rand(1, 784);
+                // Single Predict
+                System.out.println(service.predictSingle(data, "default"));
+                // Multi Predict
+                System.out.println(Arrays.toString(service.predict(new INDArray[]{data}, "default")));
+
+                break;
+            } catch (ApiException e) {
+                e.printStackTrace();
+
+                System.out.println("Couldn't try predictions with the model server, retrying: " + retries);
+                Thread.sleep(10000); // Safe sleeping time for the model server to successfully wake up.
+            }
+        } while (retries < retryCount);
     }
 }

--- a/src/test/java/ai/skymind/examples/ModelServingTest.java
+++ b/src/test/java/ai/skymind/examples/ModelServingTest.java
@@ -58,6 +58,7 @@ public class ModelServingTest {
             }
         } while (retries < retryCount);
 
-        assertTrue("Model Server workflow passed", predictionPassed);
+        assertTrue("Model Server workflow failed! Couldn't get predictions with the model server",
+                predictionPassed);
     }
 }

--- a/src/test/java/ai/skymind/examples/ModelServingTest.java
+++ b/src/test/java/ai/skymind/examples/ModelServingTest.java
@@ -11,6 +11,8 @@ import org.nd4j.linalg.io.ClassPathResource;
 import java.io.File;
 import java.util.Arrays;
 
+import static junit.framework.TestCase.assertTrue;
+
 public class ModelServingTest {
 
     @Test(timeout=900000)
@@ -34,6 +36,8 @@ public class ModelServingTest {
         int retryCount = 2;
         int retries = 0;
 
+        boolean predictionPassed = false;
+
         do {
             retries++;
 
@@ -44,6 +48,7 @@ public class ModelServingTest {
                 // Multi Predict
                 System.out.println(Arrays.toString(service.predict(new INDArray[]{data}, "default")));
 
+                predictionPassed = true;
                 break;
             } catch (ApiException e) {
                 e.printStackTrace();
@@ -52,5 +57,7 @@ public class ModelServingTest {
                 Thread.sleep(10000); // Safe sleeping time for the model server to successfully wake up.
             }
         } while (retries < retryCount);
+
+        assertTrue("Model Server workflow passed", predictionPassed);
     }
 }


### PR DESCRIPTION
Adding retries to the ModelServerTest.java for failing predictions. Sometimes the model server still isn't up and needs a little bit more time to send predictions properly.